### PR TITLE
[Expo] Added link message sharing and external activity navigation

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -1,9 +1,10 @@
 import React from 'react'
 import { NativeBaseProvider } from 'native-base'
 import { LinearGradient } from 'expo-linear-gradient'
-import { RootNavigator } from './navigation/RootNavigator'
+import { RootNavigator, navigate } from './navigation/RootNavigator'
 import { AuthenticatedUserProvider } from './providers'
 import { BaseTheme } from './theme/index'
+import * as Linking from 'expo-linking';
 
 const config = {
   dependencies: {
@@ -11,7 +12,29 @@ const config = {
   }
 }
 
+//  處理收到 url 的事件
+function handleIncomingLink(url) {
+    if (!url) return
+
+    const { hostname, path, queryParams } = Linking.parse(url);
+
+    // 直接 navigate 到活動 details 頁面，因為是 nested navigator，所以多了一個 screen 參數
+    navigate('活動', { screen: 'details', params: {Cd: queryParams.id, prepage: 'list'} })
+
+    console.log(
+        `Linked to app with hostname: ${hostname}, path: ${path} and data: ${JSON.stringify(
+            queryParams
+        )}`
+    );
+}
+
+
 export default function App () {
+  // 處理 Linking 進來的 URL
+  const url = Linking.useURL();
+  handleIncomingLink(url)  // 處理第一次收到 url 時
+  Linking.addEventListener('url', () => handleIncomingLink(url))  // 透過 listener 處理後續的 url 事件
+
   return (
     <NativeBaseProvider theme={BaseTheme} config={config}>
       <AuthenticatedUserProvider>

--- a/navigation/RootNavigator.jsx
+++ b/navigation/RootNavigator.jsx
@@ -8,6 +8,16 @@ import { AuthenticatedUserContext } from '../providers';
 import { auth } from '../config';
 import { View, Text } from 'react-native';
 
+import { createNavigationContainerRef } from '@react-navigation/native';
+
+// 使在 Navigator 以外（如 App.jsx）也能呼叫頁面導向
+export const navigationRef = createNavigationContainerRef();
+export function navigate(name, params) {
+  if (navigationRef.isReady()) {
+    navigationRef.current.navigate(name, params);
+  }
+}
+
 function SplashScreen() {
   return (
     <View>
@@ -16,8 +26,28 @@ function SplashScreen() {
   );
 }
 
+// [測試中] 大概是從主頁導向至活動頁面
+const linking = {
+  prefixes: [
+    'ncuapp://', 'exp://', '*://'
+  ],
+  config: {
+      screens: {
+          AppTabView: {
+              screens: {
+                  EventScreen: {
+                      screens: {
+                          Detailscreen: 'path/:id/'
+                      }
+                  }
+              }
+          }
+    },
+  },
+};
+
 export const RootNavigator = () => {
-  
+
   const { user, setUser } = useContext(AuthenticatedUserContext);
   const [isLoading, setIsLoading] = useState(true);
 
@@ -40,7 +70,7 @@ export const RootNavigator = () => {
   }
 
   return (
-    <NavigationContainer>
+    <NavigationContainer linking={linking} ref={navigationRef}>
       {user ? <AppTabView /> : <AuthStack />}
     </NavigationContainer>
   );

--- a/screens/Event/showActivityDetails.jsx
+++ b/screens/Event/showActivityDetails.jsx
@@ -5,6 +5,7 @@ import {
   Dimensions,
   TouchableOpacity,
   Alert,
+  Share,
 } from "react-native";
 import SvgQRCode from "react-native-qrcode-svg";
 import Dialog, { DialogContent } from "react-native-popup-dialog";
@@ -104,6 +105,18 @@ const Body = ({
   if (startTimeWeekday) startTimeList = startTimeWeekday.split(" ");
   let endTimeList = ["loading", "loading", "loading"];
   if (endTimeWeekday) endTimeList = endTimeWeekday.split(" ");
+
+  // 開啟手機系統的分享選單
+  const shareData = async () => {
+    try {
+        await Share.share({
+            // 要分享的活動連結
+            message: `ncuapp://activity?=${id}`,
+        });
+    } catch (error) {
+        alert(error.message);
+    }
+  };
 
   return (
     <Box>
@@ -220,6 +233,12 @@ const Body = ({
                     <Box style={styles.SocialApp}>
                       <SvgQRCode value={active.id} />
                     </Box>
+                    <Button onPress={() => {
+                      console.log('Link Copied');
+                      shareData();
+                    }}>
+                    點我分享
+                    </Button>
                   </ScrollView>
                 </NativeBaseProvider>
               </DialogContent>


### PR DESCRIPTION
# 活動連結分享

*目前只在 Expo 上測試過，由於生成的連結與 Expo 用的不一樣，因此生成出來的連結在 Expo 中暫無作用。*

主要是可以透過文字訊息發送活動連結；並加入了 navigator，使打開連結時會自動導向到特定的活動頁面。

## 在 Expo 上測試

可以將以下 HTML 檔案儲存到手機上，透過瀏覽器打開即可導向至 Expo。（備註：需要事先在手機Expo上打開 NCUAPP）
```html
<!DOCTYPE html>
<html lang="en" dir="ltr">
    <head>
        <meta charset="utf-8">
        <title></title>
    </head>
    <body>

    </body>
    <script type="text/javascript">
        window.location = "exp://{填入expo伺服器的IP}/--/activity/?id={填入活動 ID，如 SDebH9cGNYi5Ph1ubGX8}";
    </script>
</html>
```

## 修改內容
### App.jsx
- 新增對於外部傳入URL的導向處理
- 匯入 expo-linking 函式庫

## navigation/RootNavigator.jsx
- 新增 navigationRef 和 navigate()，使在 Navigator 以外（如 App.jsx）也能呼叫頁面導向

## screens/Event/showActivityDetails.jsx
- 在分享 QR Code 底下加上分享按鈕
- Body 內新增 shareData() 函式，可以在裡面修改分享訊息內容/連結