### PR TITLE
Fix URL Deep Linking Issue When App Is Not Started

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -28,11 +28,18 @@ function handleIncomingLink (url) {
   )
 }
 
+// 決定透過URL初始化應用時，要等多久（單位：毫秒）才轉畫面 (navigate)
+const APP_INIT_NAVIGATE_DELAY = 2000
+
+
 export default function App () {
   // 處理 Linking 進來的 URL
   const url = Linking.useURL()
-  handleIncomingLink(url) // 處理第一次收到 url 時
   Linking.addEventListener('url', () => handleIncomingLink(url)) // 透過 listener 處理後續的 url 事件
+
+   // 應用還沒打開，點 url 後才啟動
+   // 這裡給它設 2 秒延遲，否則可能會吃不到
+  setTimeout(() => { handleIncomingLink(url) }, APP_INIT_NAVIGATE_DELAY)
 
   return (
     <NativeBaseProvider theme={BaseTheme} config={config}>

--- a/app.json
+++ b/app.json
@@ -56,7 +56,7 @@
     },
     "extra": {
       "eas": {
-        "projectId": "63394f69-b1b7-467d-965a-8554ba7eeb8f"
+        "projectId": "b795d866-5d36-4bbb-9c46-c8d5446bbf26"
       }
     }
   }

--- a/app.json
+++ b/app.json
@@ -43,11 +43,7 @@
     },
     "extra": {
       "eas": {
-<<<<<<< Updated upstream
         "projectId": "b795d866-5d36-4bbb-9c46-c8d5446bbf26"
-=======
-        "projectId": "63394f69-b1b7-467d-965a-8554ba7eeb8f"
->>>>>>> Stashed changes
       }
     }
   }

--- a/app.json
+++ b/app.json
@@ -2,6 +2,7 @@
   "expo": {
     "name": "ncu-app",
     "slug": "ncu-app",
+    "scheme": "ncu-app",
     "version": "2.0.3",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
@@ -42,7 +43,11 @@
     },
     "extra": {
       "eas": {
+<<<<<<< Updated upstream
         "projectId": "b795d866-5d36-4bbb-9c46-c8d5446bbf26"
+=======
+        "projectId": "63394f69-b1b7-467d-965a-8554ba7eeb8f"
+>>>>>>> Stashed changes
       }
     }
   }

--- a/app.json
+++ b/app.json
@@ -7,7 +7,6 @@
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
-    "scheme": "ncuapp",
     "splash": {
       "image": "./assets/splash.png",
       "resizeMode": "contain",
@@ -36,14 +35,28 @@
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#FFFFFF"
+      },
+      "intentFilters": [
+      {
+        "action": "VIEW",
+        "autoVerify": true,
+        "data": [
+          {
+            "scheme": "https",
+            "host": "dynamic.link.host",
+            "pathPrefix": "/"
+          }
+        ],
+        "category": ["BROWSABLE", "DEFAULT"]
       }
+    ]
     },
     "web": {
       "favicon": "./assets/favicon.png"
     },
     "extra": {
       "eas": {
-        "projectId": "b795d866-5d36-4bbb-9c46-c8d5446bbf26"
+        "projectId": "63394f69-b1b7-467d-965a-8554ba7eeb8f"
       }
     }
   }

--- a/navigation/RootNavigator.jsx
+++ b/navigation/RootNavigator.jsx
@@ -27,7 +27,7 @@ function SplashScreen () {
 // [測試中] 大概是從主頁導向至活動頁面
 const linking = {
   prefixes: [
-    'ncuapp://', 'exp://', '*://'
+    'ncu-app://', 'exp://', '*://'
   ],
   config: {
     screens: {

--- a/screens/Event/showActivityDetails.jsx
+++ b/screens/Event/showActivityDetails.jsx
@@ -33,6 +33,8 @@ import styles from './style_folder/Styles_showActivityDetails'
 import ActiveController from '../../controller/Active'
 import MessageController from '../../controller/Message'
 import UserController from '../../controller/getStudentId'
+import * as Linking from 'expo-linking'
+
 
 const NavigationBar = (props) => (
   <ZStack width="100%" height="12%">
@@ -106,7 +108,7 @@ const Body = ({
     try {
       await Share.share({
         // 要分享的活動連結
-        message: `ncu-app://activity?=${id}`
+        message: `ncu-app://activity/?id=${id}`
       })
     } catch (error) {
       alert(error.message)

--- a/screens/Event/showActivityDetails.jsx
+++ b/screens/Event/showActivityDetails.jsx
@@ -106,7 +106,7 @@ const Body = ({
     try {
       await Share.share({
         // 要分享的活動連結
-        message: `ncuapp://activity?=${id}`
+        message: `ncu-app://activity?=${id}`
       })
     } catch (error) {
       alert(error.message)


### PR DESCRIPTION
# 修復：當應用還沒執行時，透過 URL 打開會無法跳轉畫面

_抱歉我又忘記把 `app.json` 裡的 `projectId` 改回去了_

## 具體改動：

- `app.json`：新增 `scheme` 一欄（讓系統知道要打開應用）；新增 Android intent filters
- `App.jsx`：新增應用初始化時，畫面跳轉的延遲（`APP_INIT_NAVIGATE_DELAY`，單位：毫秒）
- `showActivityDetails.jsx`：修正活動連結分享的URL格式

## 測試

可以將以下 HTML 檔案儲存到手機上，透過瀏覽器打開即可導向至 NCUAPP。
```html
<!DOCTYPE html>
<html lang="en" dir="ltr">
    <head>
        <meta charset="utf-8">
        <title></title>
    </head>
    <body>

    </body>
    <script type="text/javascript">
        window.location = "ncu-app://activity/?id={填入活動 ID，如 SDebH9cGNYi5Ph1ubGX8}";
    </script>
</html>
```

## 備註

- Delay 的秒數可以調整，1秒偶爾會吃不到，所以保險起見調成2秒

- 後續需要把上面的 HTML 檔案架到一個網頁上，當使用者點擊活動分享時，URL 應該導向至那個網頁。這樣才能透過用戶手機的瀏覽器把觸發 NCU-APP 應用。（不少應用都是這樣做的）